### PR TITLE
changing $TODO_SH => $TODO_FULL_SH

### DIFF
--- a/todo.actions.d/add
+++ b/todo.actions.d/add
@@ -26,9 +26,9 @@ elif [ x"$1" = x"x" ]; then
 fi
 
 # call back to the main script to add
-if "$TODO_SH" command add "$@"; then
+if "$TODO_FULL_SH" command add "$@"; then
     # figure out the line of what we just added, and "do" it
     line=`sed -n '$ =' "$TODO_FILE"`
-    [ $PRIORITY != false ] && "$TODO_SH" command pri "$line" $PRIORITY
-    $DO && "$TODO_SH" command do "$line"
+    [ $PRIORITY != false ] && "$TODO_FULL_SH" command pri "$line" $PRIORITY
+    $DO && "$TODO_FULL_SH" command do "$line"
 fi


### PR DESCRIPTION
 $TODO_SH env var points to a filename which is todo.sh, where it's better to have a full path with $TODO_FULL_SH. For those who have todo.sh in a custom location will run into: a "command not found" error at line 29.

 $TODO_SH = $(basename full/path/to/todo.sh) => todo.sh
